### PR TITLE
지나간 페이지 히스토리 기록

### DIFF
--- a/Assets/Scripts/EpisodeCollection.cs
+++ b/Assets/Scripts/EpisodeCollection.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 public class EpisodeCollection
 {
-    DirectoryInfo dir = new DirectoryInfo(Application.dataPath+"/Scripts/Resources/Episodes");
+    DirectoryInfo dir = new DirectoryInfo(Application.dataPath + "/Scripts/Resources/Episodes");
     List<Episode> episodes = new List<Episode> { };
     List<Episode> tutorialEpisodes = new List<Episode> { };
     private static readonly EpisodeCollection instance = new EpisodeCollection();
@@ -18,16 +18,13 @@ public class EpisodeCollection
     public static EpisodeCollection Instance { get => instance; }
     private void CollectEpisode()
     {
-        foreach(var item in dir.GetFiles())
+        foreach(FileInfo item in dir.GetFiles("*.json"))
         {
-            var temp = item.Name;
-            if (!temp.Contains("meta"))
-            {
-                temp = temp.Substring(0, temp.IndexOf("."));
-                episodes.Add(Episode.Load(temp));
-                if (temp.Contains("tutorial"))
-                    tutorialEpisodes.Add(Episode.Load(temp));
-            }
+            string fileName = item.Name;
+            string episodeId = fileName.Substring(0, fileName.IndexOf("."));
+            episodes.Add(Episode.Load(episodeId));
+            if (episodeId.Contains("tutorial"))
+                tutorialEpisodes.Add(Episode.Load(episodeId));
         }
     }
     public void PrintEpisode()

--- a/Assets/Scripts/EpisodePlayer.cs
+++ b/Assets/Scripts/EpisodePlayer.cs
@@ -7,30 +7,41 @@ public class EpisodePlayer
     private Episode episode;
     private Page currentPage;
     private int currentStar;
+    private Dictionary<string, int> pageHistory;
+    
     private static readonly EpisodePlayer instance = new EpisodePlayer();
     static EpisodePlayer() {}
     private EpisodePlayer() {}
+    
     public static EpisodePlayer Instance { get => instance; }
-    public static int CurrentStar { get {
+    public static int CurrentStar 
+    {
+         get {
             if (Instance.currentStar < 0) return 0;
             else if (Instance.currentStar < 3) return Instance.currentStar;
             else return 3;
-        }}
+        }
+    }
     public static bool isReady { get => Instance.episode != null; }
-
     public static Episode CurrentEpisode { get => Instance.episode; }
     public static Page CurrentPage { get => Instance.currentPage; }
-
+    
     public static void SetEpisode(Episode episode)
     {
         Instance.episode = episode;
         Instance.currentPage = episode.startPage;
+        Instance.pageHistory = new Dictionary<string, int> { { Instance.currentPage.id, 1 } };
         Instance.currentStar = 3;
     }
-
+    
     public static void SelectAction(Action action)
     {
         Instance.currentStar += action.starChange;
         Instance.currentPage = Instance.episode.pages[action.linkedPageId];
+        
+        if (Instance.pageHistory.TryGetValue(Instance.currentPage.id, out int value))
+            Instance.pageHistory[Instance.currentPage.id] = value + 1;
+        else
+            Instance.pageHistory[Instance.currentPage.id] = 1;
     }
 }

--- a/Assets/Scripts/EpisodePlayer.cs
+++ b/Assets/Scripts/EpisodePlayer.cs
@@ -20,15 +20,17 @@ public class EpisodePlayer
 
     public static Episode CurrentEpisode { get => Instance.episode; }
     public static Page CurrentPage { get => Instance.currentPage; }
-    public static void StarChange(int index) 
-    {
-        Instance.currentStar += index;
-    }
 
     public static void SetEpisode(Episode episode)
     {
         Instance.episode = episode;
         Instance.currentPage = episode.startPage;
         Instance.currentStar = 3;
+    }
+
+    public static void SelectAction(Action action)
+    {
+        Instance.currentStar += action.starChange;
+        Instance.currentPage = Instance.episode.pages[action.linkedPageId];
     }
 }

--- a/Assets/Scripts/EpisodePlayer.cs
+++ b/Assets/Scripts/EpisodePlayer.cs
@@ -38,10 +38,17 @@ public class EpisodePlayer
     {
         Instance.currentStar += action.starChange;
         Instance.currentPage = Instance.episode.pages[action.linkedPageId];
-        
+        Instance.pageHistory[Instance.currentPage.id] = GetVisitCount(Instance.currentPage) + 1;
+    }
+    public static int GetVisitCount(Page page)
+    {
         if (Instance.pageHistory.TryGetValue(Instance.currentPage.id, out int value))
-            Instance.pageHistory[Instance.currentPage.id] = value + 1;
+            return value;
         else
-            Instance.pageHistory[Instance.currentPage.id] = 1;
+            return 0;
+    }
+    public static bool HasVisited(Page page)
+    {
+        return GetVisitCount(page) > 0;
     }
 }

--- a/Assets/Scripts/SelectPanelController.cs
+++ b/Assets/Scripts/SelectPanelController.cs
@@ -23,7 +23,7 @@ public class SelectPanelController : MonoBehaviour
 
     public void OnPageUpdated(Page page)
     {
-        if (page.isEnd == true) //해당 페이지가 끝인 경우
+        if (page.isEnd) //해당 페이지가 끝인 경우
         {
             resultPanel.SetActive(true);
             Debug.Log($"별의 갯수 :{EpisodePlayer.CurrentStar}");
@@ -38,14 +38,14 @@ public class SelectPanelController : MonoBehaviour
                 button.transform.GetComponentInChildren<Text>().text = action.title;
                 button.GetComponent<Button>().onClick.AddListener(() =>
                 {
-                    EpisodePlayer.StarChange(action.starChange);
+                    EpisodePlayer.SelectAction(action);
                     while (buttonList.Count != 0)
                     {
                         Destroy(buttonList.ElementAt(0));
                         buttonList.RemoveAt(0);
                     }
-                    storyPanel.OnPageUpdated(EpisodePlayer.CurrentEpisode.pages[action.linkedPageId]);
-                    OnPageUpdated(EpisodePlayer.CurrentEpisode.pages[action.linkedPageId]);
+                    storyPanel.OnPageUpdated(EpisodePlayer.CurrentPage);
+                    OnPageUpdated(EpisodePlayer.CurrentPage);
                     Debug.Log($"Selected: {action.title}");
                 });
             }


### PR DESCRIPTION
- 페이지 히스토리 기록
    - 특정 페이지에 몇 번 방문했는지까지 기록(나중에 쓸모 있을까봐)
- 액션 선택 후 로직을 `EpisodePlayer` 클래스로 모음
    - 별 증감, 다음 페이지로 이동, 히스토리 기록
- `GetVisitCount`, `HasVisited` 메소드 구현
- `meta`가 아닌 파일을 에피소드 파일로 인식하던 걸 `*.json` 파일만 에피소드 파일로 인식하도록 수정
    - macOS에서 `.DS_Store`를 읽으려고 해서 문제가 발생했음