### PR TITLE
결과 패널을 기획에 맞게 수정

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -153,10 +153,10 @@ RectTransform:
   m_Father: {fileID: 1893873070}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 154.5, y: -14}
+  m_SizeDelta: {x: 309, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &189649140
 MonoBehaviour:
@@ -232,10 +232,10 @@ RectTransform:
   m_Father: {fileID: 990457458}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 80, y: 28}
-  m_SizeDelta: {x: 70, y: 70}
+  m_AnchorMin: {x: 0.5, y: 0.65}
+  m_AnchorMax: {x: 0.5, y: 0.65}
+  m_AnchoredPosition: {x: 80, y: -0.5}
+  m_SizeDelta: {x: 60, y: 59}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &299353546
 MonoBehaviour:
@@ -577,10 +577,10 @@ RectTransform:
   m_Father: {fileID: 990457458}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 28}
-  m_SizeDelta: {x: 70, y: 70}
+  m_AnchorMin: {x: 0.5, y: 0.65}
+  m_AnchorMax: {x: 0.5, y: 0.65}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: 60, y: 59}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &516814773
 MonoBehaviour:
@@ -849,10 +849,10 @@ RectTransform:
   m_Father: {fileID: 299353545}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 70, y: 70}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &694107775
 MonoBehaviour:
@@ -1048,10 +1048,10 @@ RectTransform:
   m_Father: {fileID: 836344065}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 70, y: 70}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &759204697
 MonoBehaviour:
@@ -1123,10 +1123,10 @@ RectTransform:
   m_Father: {fileID: 990457458}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: 28}
-  m_SizeDelta: {x: 70, y: 70}
+  m_AnchorMin: {x: 0.5, y: 0.65}
+  m_AnchorMax: {x: 0.5, y: 0.65}
+  m_AnchoredPosition: {x: -80, y: -0.5}
+  m_SizeDelta: {x: 60, y: 59}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &836344066
 MonoBehaviour:
@@ -1208,13 +1208,14 @@ RectTransform:
   - {fileID: 516814772}
   - {fileID: 299353545}
   - {fileID: 2042611187}
+  - {fileID: 1905503845}
   m_Father: {fileID: 2005318940}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 394, y: 0}
-  m_SizeDelta: {x: 300, y: 200}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 608, y: -12.5}
+  m_SizeDelta: {x: 0, y: -55}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &990457459
 MonoBehaviour:
@@ -1518,7 +1519,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Button
+  m_Text: "\uD0D0\uC815 \uC0AC\uBB34\uC18C\uB85C \uB3CC\uC544\uAC04\uB2E4"
 --- !u!222 &1089320822
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1718,10 +1719,10 @@ RectTransform:
   m_Father: {fileID: 516814772}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 70, y: 70}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1201468725
 MonoBehaviour:
@@ -2291,6 +2292,84 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+--- !u!1 &1905503844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1905503845}
+  - component: {fileID: 1905503847}
+  - component: {fileID: 1905503846}
+  m_Layer: 5
+  m_Name: EpisodeName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1905503845
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905503844}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 990457458}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.85}
+  m_AnchorMax: {x: 1, y: 0.85}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 29}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1905503846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905503844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: "\uC5D0\uD53C\uC18C\uB4DC \uC774\uB984"
+--- !u!222 &1905503847
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905503844}
+  m_CullTransparentMesh: 0
 --- !u!1 &2005318936
 GameObject:
   m_ObjectHideFlags: 0
@@ -2492,10 +2571,10 @@ RectTransform:
   m_Father: {fileID: 990457458}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -40}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchorMin: {x: 0.5, y: 0.05}
+  m_AnchorMax: {x: 0.5, y: 0.05}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2042611188
 MonoBehaviour:
@@ -2753,8 +2832,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -20}
-  m_SizeDelta: {x: 0, y: -40}
+  m_AnchoredPosition: {x: 0, y: -12.5}
+  m_SizeDelta: {x: -10, y: -55}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2127335421
 MonoBehaviour:

--- a/Assets/Scripts/ResultPanelController.cs
+++ b/Assets/Scripts/ResultPanelController.cs
@@ -8,16 +8,23 @@ public class ResultPanelController : MonoBehaviour
     GameObject resultPanel;
     Button resultButton;
     GameObject[] stars = new GameObject[3];
+    RectTransform rectTransform;
+    Text episodeName;
+    Text clearText;
     bool firstStart =true;
     // Start is called before the first frame update
     void Start()
     {
         resultPanel = GameObject.Find("ResultPanel").gameObject;
+        episodeName = GameObject.Find("ResultPanel/EpisodeName").GetComponent<Text>();
+        clearText = GameObject.Find("ResultPanel/ClearText").GetComponent<Text>();
         resultButton = GameObject.Find("ResultPanel/ResultButton").GetComponent<Button>();
         resultButton.onClick.AddListener(OnClickResultButton);
         for (int i = 0; i < 3; i++)
             stars[i] = GameObject.Find($"ResultPanel/Star{i + 1}/").transform.Find("Image").gameObject;
-        resultPanel.transform.localPosition = new Vector3(0,0,0);
+        rectTransform = resultPanel.GetComponent<RectTransform>();
+        rectTransform.anchoredPosition = GameObject.Find("Canvas/VertialLayout").GetComponent<RectTransform>().anchoredPosition;
+        rectTransform.sizeDelta = GameObject.Find("Canvas/VertialLayout").GetComponent<RectTransform>().sizeDelta;
         resultPanel.SetActive(false);
         firstStart = false;
     }
@@ -42,8 +49,19 @@ public class ResultPanelController : MonoBehaviour
         if (!firstStart)
         {
             ResultStar(EpisodePlayer.CurrentStar);
-            var clear = false;
-            if (0<EpisodePlayer.CurrentStar) clear = true;
+            episodeName.text ="Ep."+ EpisodePlayer.CurrentEpisode.title;
+            bool clear;
+            if (0 < EpisodePlayer.CurrentStar)
+            {
+                clear = true;
+                clearText.text = "의뢰 성공!";
+            }
+            else
+            {
+                clear = false;
+                clearText.text = "의뢰 실패...";
+            }
+
             SaveData.Instance.AddclearEpisodeList(EpisodePlayer.CurrentEpisode.id,clear,EpisodePlayer.CurrentStar);
         }
     }

--- a/Assets/Scripts/SelectPanelController.cs
+++ b/Assets/Scripts/SelectPanelController.cs
@@ -25,8 +25,18 @@ public class SelectPanelController : MonoBehaviour
     {
         if (page.isEnd) //해당 페이지가 끝인 경우
         {
-            resultPanel.SetActive(true);
-            Debug.Log($"별의 갯수 :{EpisodePlayer.CurrentStar}");
+            GameObject button = Instantiate(ButtonPrefab, ButtonHolder.transform);
+            buttonList.Add(button);
+            button.transform.GetComponentInChildren<Text>().text = "[엔딩]";
+            button.GetComponent<Button>().onClick.AddListener(() =>
+            {
+                while (buttonList.Count != 0)
+                {
+                    Destroy(buttonList.ElementAt(0));
+                    buttonList.RemoveAt(0);
+                }
+                 resultPanel.SetActive(true);
+            });
         }
         else //페이지가 끝이 아닐 경우
         {


### PR DESCRIPTION
[관련 task](https://www.notion.so/74231da3f8994973aeb9fd0f934f7a03)
- 결과 패널이 끝페이지에 바로 뜨지 않고 엔딩버튼을 눌러야 뜨도록 설정
- 결과 패널의 크기를 스토리+선택 패널의 크기와 동일하게 변경 ("VertialLayout"의 RectTransform 컴포넌트(사이즈) 바꾸면 같이 바뀜)
- 스토리+선택 패널에 여백(?) 추가
- 결과 패널의 에피소드 타이틀, 클리어 여부 추가 (담당자 관련 텍스트는 나중에 추가 해야함..)