### PR TITLE
스토리 본문 해석 방법을 바꾸기

### DIFF
--- a/Assets/Scripts/PassageLexer.cs
+++ b/Assets/Scripts/PassageLexer.cs
@@ -130,10 +130,6 @@ public class PassageLexer
                             string symbol = match.Groups["symbol"].Value;
                             yield return new Token(tokenDef.type, symbol);
                             break;
-                        // case TokenType.String:
-                        //     string value = match.Groups["value"].Value;
-                        //     yield return new Token(tokenDef.type, value);
-                        //     break;
                         default:
                             yield return new Token(tokenDef.type, match.Value);
                             break;

--- a/Assets/Scripts/PassageLexer.cs
+++ b/Assets/Scripts/PassageLexer.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Linq;
+using UnityEngine;
+
+public enum TokenType 
+{
+    Set, If, ElseIf, Else, Symbol, Value,
+    String, Float, Int, Bool,
+    IsNot, Is, Operator,
+    WhiteSpace, Text
+}
+
+public class Token
+{
+    public TokenType type;
+    public string content;
+    public List<Token> contents;
+
+    public Token(TokenType type, string content)
+    {
+        this.type = type;
+        this.content = content;
+    }
+
+    public Token(TokenType type, List<Token> contents)
+    {
+        this.type = type;
+        this.contents = contents;
+    }
+
+    public override string ToString()
+    {
+        if (this.contents == null)
+            return $"T({this.type.ToString()}, \"{Regex.Escape(this.content)}\")";
+        else
+        {
+            List<string> stringContents = new List<string>();
+            foreach (var token in this.contents)
+                stringContents.Add(token.ToString());
+            return $"T({this.type.ToString()}, [\n{String.Join("\n", stringContents)}\n])";
+        }
+    }
+}
+
+public class TokenDef
+{
+    public TokenType type;
+    public Regex rx;
+
+    public TokenDef(TokenType type, string pattern)
+    {
+        this.type = type;
+        this.rx = new Regex($@"\G{pattern}");
+    }
+}
+
+public class PassageLexer
+{
+    static List<TokenDef> tokenDefs = new List<TokenDef>
+    {
+        new TokenDef(TokenType.Set, @"\(set:\s*\$(?<symbol>[a-zA-Z0-9_-]+) to (?<value>.+?)\)"),
+        new TokenDef(TokenType.If, @"\(if:\s*(?<condition>.+?)\)\s*\[\s*(?<body>.+?)\s*\]"),
+        new TokenDef(TokenType.ElseIf, @"\(else-if:\s*(?<condition>.+?)\)\s*\[\s*(?<body>.+?)\s*\]"),
+        new TokenDef(TokenType.Else, @"\(else:\s*\)\s*\[\s*(?<body>.+?)\s*\]"),
+        new TokenDef(TokenType.Symbol, @"\$(?<symbol>[a-zA-Z0-0_-]+)"),
+        new TokenDef(TokenType.String, @"""(?<value>.+)"""),
+        new TokenDef(TokenType.Float, @"[-+]?\d*\.\d+([eE][-+]?\d+)?"),
+        new TokenDef(TokenType.Int, @"[-+]?\d+"),
+        new TokenDef(TokenType.Bool, @"(true|false)"),
+        new TokenDef(TokenType.IsNot, @"is not"),
+        new TokenDef(TokenType.Is, @"is"),
+        new TokenDef(TokenType.Operator, @"[-+*/><]=?"),
+        new TokenDef(TokenType.WhiteSpace, @"\s"),
+        new TokenDef(TokenType.Text, @"."),
+    };
+
+    public static IEnumerable<Token> Tokenize(string text)
+    {
+        int cursor = 0;
+        while (cursor < text.Length)
+        {
+            foreach (TokenDef tokenDef in tokenDefs)
+            {
+                Match match = tokenDef.rx.Match(text, startat: cursor);
+                if(match.Success)
+                {
+                    switch(tokenDef.type)
+                    {
+                        case TokenType.Set:
+                            string setSymbol = match.Groups["symbol"].Value; 
+                            string setValue = match.Groups["value"].Value;
+                            yield return new Token
+                            (
+                                tokenDef.type, new List<Token>
+                                {
+                                    new Token(TokenType.Symbol, setSymbol),
+                                    new Token(TokenType.Value, Tokenize(setValue).ToList()),
+                                }
+                            );
+                            break;
+                        case TokenType.If:
+                        case TokenType.ElseIf:
+                            string ifCondition = match.Groups["condition"].Value; 
+                            string ifBody = match.Groups["body"].Value;
+                            yield return new Token
+                            (
+                                tokenDef.type, new List<Token>
+                                {
+                                    new Token(TokenType.Value, Tokenize(ifCondition).ToList()),
+                                    new Token(TokenType.Value, Tokenize(ifBody).ToList()),
+                                }
+                            );
+                            break;
+                        case TokenType.Else:
+                            string elseBody = match.Groups["body"].Value;
+                            yield return new Token
+                            (
+                                tokenDef.type, new List<Token>
+                                {
+                                    new Token(TokenType.Value, Tokenize(elseBody).ToList()),
+                                }
+                            );
+                            break;
+                        case TokenType.Symbol:
+                            string symbol = match.Groups["symbol"].Value;
+                            yield return new Token(tokenDef.type, symbol);
+                            break;
+                        default:
+                            yield return new Token(tokenDef.type, match.Value);
+                            break;
+                    }
+                    cursor += match.Length;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PassageLexer.cs
+++ b/Assets/Scripts/PassageLexer.cs
@@ -35,14 +35,14 @@ public class Token
 
     public override string ToString()
     {
-        if (this.contents == null)
-            return $"T({this.type.ToString()}, \"{Regex.Escape(this.content)}\")";
+        if (contents == null)
+            return $"T({type.ToString()}, \"{Regex.Escape(content)}\")";
         else
         {
             List<string> stringContents = new List<string>();
-            foreach (var token in this.contents)
+            foreach (var token in contents)
                 stringContents.Add(token.ToString());
-            return $"T({this.type.ToString()}, [\n{String.Join("\n", stringContents)}\n])";
+            return $"T({type.ToString()}, [\n{String.Join("\n", stringContents)}\n])";
         }
     }
 }
@@ -130,6 +130,10 @@ public class PassageLexer
                             string symbol = match.Groups["symbol"].Value;
                             yield return new Token(tokenDef.type, symbol);
                             break;
+                        // case TokenType.String:
+                        //     string value = match.Groups["value"].Value;
+                        //     yield return new Token(tokenDef.type, value);
+                        //     break;
                         default:
                             yield return new Token(tokenDef.type, match.Value);
                             break;

--- a/Assets/Scripts/PassageLexer.cs.meta
+++ b/Assets/Scripts/PassageLexer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69b4e2c04e0f14f7c9deab1f9efe6be6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PassageProcessor.cs
+++ b/Assets/Scripts/PassageProcessor.cs
@@ -1,7 +1,8 @@
 using System;
-using System.Data;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
+using System.Text;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -54,6 +55,45 @@ public class PassageProcessor
             var value = table.Compute(processedExpression, string.Empty);
             return table.Compute(processedExpression, string.Empty);
         }
+    }
+
+    private bool EvalCondition(string condition)
+    {
+        Regex isNotRegex = new Regex(@"(?<exp1>.+) is not (?<exp2>.+)");
+        Match isNotMatch = isNotRegex.Match(condition);
+        if(isNotMatch.Success)
+        {
+            GroupCollection groups = isNotMatch.Groups;
+            var exp1 = Eval(groups["exp1"].Value);
+            var exp2 = Eval(groups["exp2"].Value);
+            return exp1 != exp2;
+        }
+
+        Regex isRegex = new Regex(@"(?<exp1>.+) is (?<exp2>.+)");
+        Match isMatch = isRegex.Match(condition);
+        if(isMatch.Success)
+        {
+            GroupCollection groups = isMatch.Groups;
+            var exp1 = Eval(groups["exp1"].Value);
+            var exp2 = Eval(groups["exp2"].Value);
+            return exp1 == exp2;
+        }
+
+        return (bool)Eval(condition);
+    }
+
+    private string ProcessIfMacro(string originText)
+    {
+        Regex rx = new Regex(@"\(if:\s*(?<condition>.+?)\)\[(?<body>.+?)\]");
+        MatchCollection matches = rx.Matches(originText);
+        foreach (Match match in matches)
+        {
+            GroupCollection groups = match.Groups;
+            bool contidion = EvalCondition(groups["condition"].Value);
+            if (contidion) {}
+        }
+        string setRemovedText = rx.Replace(originText, "").Trim();
+        return setRemovedText;
     }
 
     private string ProcessSetMacro(string originText)


### PR DESCRIPTION
노션 링크
- https://www.notion.so/e6ec7da8916a4c51af59f5c9e8bb5b8f

동작 방법
- `PassageLexer`가 passage text를 token tree로 인코딩
- `PassageProcessor`가 token tree를 처리

Tokenize 예시
```Python
sample_text = '''
a (set: $a to 1)
(if:$a >= 2 - 1) [a >= 1(set: $a to 3)](else:)[나오면 안 됨]
$a
'''
```
->
```
[
  T('\n', white-space),
  T('a', text),
  T(' ', white-space),
  [ T('set', set), T('a', symbol), [T('1', int)] ],  // a에 1을 대입
  T('\n', white-space),
  [
    T('if', if),
    [  // 조건
      T('a', symbol), T('>=', operator), T('2', int), T('-', operator), T('1', int)
    ],
    [  // 본문
      T('a', text), T(' ', white-space), T('>=', operator), T(' ', white-space), T('1', int),
      [ T('set', set), T('a', symbol), [ T('3', int)] ]  // 본문 안에 set, if 등 매크로가 들어갈 수 있음
    ]
  ],
  [
    T('else', else),
    [
      T('나', text), T('오', text), T('면', text), T(' ', white-space), T('안', text), T(' ', white-space), T('됨', text)
    ]
  ],
  T('\n', white-space),
  T('a', symbol),
  T('\n', white-space)
]
```

참고 링크
- lexer란: https://en.wikipedia.org/wiki/Lexical_analysis
- Pascal lexer with Python: https://ruslanspivak.com/lsbasi-part9/
- Poor man's lexer with C#: https://stackoverflow.com/a/673657