### PR TITLE
스토리 패널 타이핑효과 개선

### DIFF
--- a/Assets/Scripts/SelectPanelController.cs
+++ b/Assets/Scripts/SelectPanelController.cs
@@ -25,11 +25,11 @@ public class SelectPanelController : MonoBehaviour
  
     IEnumerator OnPassageUpdatedCoroutine(Passage passage)
     {
-        while (!storyPanel.endTyping)
+        while (!storyPanel.EndTyping)
         {
             yield return null;
         }
-        storyPanel.endTyping = false;
+        storyPanel.EndTyping = false;
         if (passage.isEnd) //해당 페이지가 끝인 경우
         {
             GameObject button = Instantiate(ButtonPrefab, ButtonHolder.transform);

--- a/Assets/Scripts/StoryPanelController.cs
+++ b/Assets/Scripts/StoryPanelController.cs
@@ -9,12 +9,14 @@ public class StoryPanelController : MonoBehaviour
 {
     Text storyText;
     Button backButton;
-    bool checkSkipTyping = false;
-    public bool endTyping = false;
+    GameObject selectPanel;
+    public bool EndTyping { get ; set; }
+    private bool CheckSkipTyping { get; set; }
     void Start()
     {
         storyText = GameObject.Find("StoryText").GetComponent<Text>();
         backButton = GameObject.Find("Canvas/BackButton").GetComponent<Button>();
+        selectPanel = GameObject.Find("Canvas/VertialLayout/SelectPanel");
         backButton.onClick.AddListener(OnClickBackButton);
         
         if (StoryPlayer.isReady)
@@ -31,9 +33,9 @@ public class StoryPanelController : MonoBehaviour
             EventSystem.current.RaycastAll(pointerEventData, raycastResults);
             foreach(var result in raycastResults)
             {
-               if( result.gameObject == this.gameObject)
+                if ((result.gameObject == this.gameObject)||(result.gameObject == selectPanel))
                 {
-                    checkSkipTyping = true;
+                    CheckSkipTyping = true;
                 }
             }
         }
@@ -46,6 +48,7 @@ public class StoryPanelController : MonoBehaviour
 
     public void OnPassageUpdated()
     {
+        CheckSkipTyping = false;
         var temp = TypeCoroutine(storyText, StoryPlayer.CurrentPassage.text);
         StartCoroutine(temp);
     }
@@ -53,19 +56,19 @@ public class StoryPanelController : MonoBehaviour
     {
         for (int i = 0; i < description.Length; i++)
         {
-            if (!checkSkipTyping)
+            if (!CheckSkipTyping)
             {
                 text.text = description.Substring(0, i);
-                yield return new WaitForSeconds(0.1f);
+                yield return new WaitForSeconds(0.05f);
             }
             else
             {
                 text.text = description;
-                endTyping = true;
-                checkSkipTyping = false;
+                EndTyping = true;
+                CheckSkipTyping = false;
                 yield break;
             }
         }
-        endTyping = true;
+        EndTyping = true;
     }
 }


### PR DESCRIPTION
- GameScene에서 스토리패널 뿐만 아니라 버튼 패널을 눌러도 타이핑효과가 스킵되도록 설정 
-  타이핑효과가 완료된 상태에서 스토리패널을 누르고 버튼을 누르면 다음에 나올 타이핑효과가 스킵되는 버그 수정
- 타이핑 애니메이션을 빠르게 나오도록 함 (0.1초->0.05초)
- 코루틴에서 쓰는 변수들을 어디서 쓰는 지 알수있게 프로퍼티로 바꿈